### PR TITLE
Add classes for row display

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -26,7 +26,10 @@
     [(selection)]="selection"
   ></app-radio-button-group>
   <br>
-  <br>
+
+  <app-button-group [buttons]="buttons"></app-button-group>
+  <app-button-group row [buttons]="buttons"></app-button-group>
+  
   <br>
   <app-button
     content="Submit"

--- a/src/app/components/button-group/button-group.component.css
+++ b/src/app/components/button-group/button-group.component.css
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  margin: 10px 0;
+}

--- a/src/app/components/button-group/button-group.component.html
+++ b/src/app/components/button-group/button-group.component.html
@@ -1,5 +1,5 @@
-<ul class="slds-button-group-list">
-    <li *ngFor="let button of outerButtons">
+<ul [ngClass]="displayAsRow ? 'slds-button-group-row' : 'slds-button-group-list'">
+    <li *ngFor="let button of outerButtons" [ngClass]="displayAsRow ? 'slds-button-group-item' : ''">
       <app-button
         [content]="button['content']"
         [type]="button['type']"

--- a/src/app/components/button-group/button-group.component.ts
+++ b/src/app/components/button-group/button-group.component.ts
@@ -1,8 +1,10 @@
 import { Component, Input } from '@angular/core';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 
 @Component({
   selector: 'app-button-group',
-  templateUrl: './button-group.component.html'
+  templateUrl: './button-group.component.html',
+  styleUrls: ['./button-group.component.css']
 })
 export class ButtonGroupComponent { // Will eventually need to incorporate overlay for dropdown
 
@@ -17,7 +19,12 @@ export class ButtonGroupComponent { // Will eventually need to incorporate overl
 
   }
 
+  @Input() set row(value: any) {
+    this.displayAsRow = coerceBooleanProperty(value);
+  }
+
   innerButtons: object[];
   outerButtons: object[];
   overflow = false;
+  displayAsRow = false
 }


### PR DESCRIPTION
I added two button groups, one for each mode, on the main page.

About the CSS `display: block`, I added that because Angular makes all components `display: inline` by default, which doesn't seem appropriate for UI elements. Here is a relevant issue: https://github.com/angular/angular/issues/5960